### PR TITLE
Add basic localization

### DIFF
--- a/lib/home/components/title_list.dart
+++ b/lib/home/components/title_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:parkz/utils/constanst.dart';
 import 'package:parkz/utils/text/semi_bold.dart';
+import '../../l10n/app_localizations.dart';
 
 class TitleList extends StatelessWidget {
   final String title;
@@ -21,7 +22,7 @@ class TitleList extends StatelessWidget {
               MaterialPageRoute(builder: (context) => page!),
             );
           },
-          child: const SemiBoldText(text: 'Xem thêm', fontSize: 15, color: AppColor.navy)
+          child: SemiBoldText(text: AppLocalizations.of(context).seeMore, fontSize: 15, color: AppColor.navy)
         ) : const SizedBox(),
       ],
     );

--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -18,6 +18,8 @@ import 'package:parkz/utils/preference_manager.dart';
 import 'package:parkz/utils/text/regular.dart';
 import 'package:parkz/utils/text/semi_bold.dart';
 import 'package:provider/provider.dart';
+import '../main.dart';
+import '../l10n/app_localizations.dart';
 
 import '../model/rating_home_response.dart';
 import '../utils/warning__flag_provider.dart';
@@ -73,8 +75,8 @@ class _HomePageState extends State<HomePage> {
         context: context,
         dialogType: DialogType.warning,
         animType: AnimType.bottomSlide,
-        title: 'Thông báo',
-        desc: 'Chúng tôi xin thông báo rằng nếu bạn tiếp tục không đến bãi xe theo lịch đặt, chúng tôi sẽ phải ngưng sử dụng dịch vụ của bạn để duy trì công bằng và đảm bảo tính sẵn sàng cho tất cả người dùng.',
+        title: AppLocalizations.of(context).noticeTitle,
+        desc: AppLocalizations.of(context).banWarningOne,
         btnOkOnPress: () {
           warningFlagProvider.setWarningFlag(true);
         },
@@ -87,8 +89,8 @@ class _HomePageState extends State<HomePage> {
         context: context,
         dialogType: DialogType.error,
         animType: AnimType.bottomSlide,
-        title: 'Thông báo',
-        desc: 'Chúng tôi tiếc báo rằng dịch vụ của bạn đã bị tạm ngưng do không tuân thủ lịch đặt tại bãi xe. Để tiếp tục sử dụng dịch vụ, vui lòng liên hệ với chúng tôi để biết thêm chi tiết và hướng dẫn khắc phục. Chúng tôi rất mong nhận được sự hợp tác của bạn trong việc duy trì trật tự và công bằng cho cộng đồng người dùng của chúng tôi.',
+        title: AppLocalizations.of(context).noticeTitle,
+        desc: AppLocalizations.of(context).banWarningTwo,
         btnOkOnPress: () {
           storage.delete(key: 'token');
           storage.delete(key: 'userID');
@@ -119,6 +121,21 @@ class _HomePageState extends State<HomePage> {
               slivers: <Widget> [
                 SliverAppBar(
                   automaticallyImplyLeading: false,
+                  actions: [
+                    IconButton(
+                      icon: const Icon(Icons.language),
+                      onPressed: () {
+                        final state = MyApp.of(context);
+                        if (state != null) {
+                          if (state.locale.languageCode == 'en') {
+                            state.setLocale(const Locale('vi', 'VN'));
+                          } else {
+                            state.setLocale(const Locale('en', 'US'));
+                          }
+                        }
+                      },
+                    )
+                  ],
                   title: Padding(
                     padding: const EdgeInsets.only( right: 5),
                     child: SizedBox(
@@ -137,9 +154,9 @@ class _HomePageState extends State<HomePage> {
                                   crossAxisAlignment: CrossAxisAlignment.start,
                                   mainAxisAlignment: MainAxisAlignment.center,
                                   children:  [
-                                    const RegularText(text: 'Vị trí của bạn', fontSize: 12, color: AppColor.navyPale),
+                                    RegularText(text: AppLocalizations.of(context).yourLocation, fontSize: 12, color: AppColor.navyPale),
                                     //address
-                                    SemiBoldText(maxLine: 1, text: address != null ? '$address' : 'Loading...',
+                                    SemiBoldText(maxLine: 1, text: address != null ? '$address' : AppLocalizations.of(context).loading,
                                       fontSize: 14,
                                       color: Colors.white,
                                     ),
@@ -174,9 +191,9 @@ class _HomePageState extends State<HomePage> {
                       children: [
                         const SizedBox(height: 16),
 
-                        const Padding(
-                          padding: EdgeInsets.only(left: 20.0, right: 16),
-                          child: TitleList(title: 'Gần bạn', page: ParkingListPage()),
+                        Padding(
+                          padding: const EdgeInsets.only(left: 20.0, right: 16),
+                          child: TitleList(title: AppLocalizations.of(context).nearYou, page: const ParkingListPage()),
                         ),
 
                         FutureBuilder<NearestParkingResponse>(
@@ -210,25 +227,25 @@ class _HomePageState extends State<HomePage> {
                                 ),
                               );
                             }else {
-                              return const SizedBox(
+                              return SizedBox(
                                 width: double.infinity,
                                 height: 310,
-                                child: Center(child: SemiBoldText(text: 'Không có bãi xe gần bạn', fontSize: 19, color: AppColor.forText),),
+                                child: Center(child: SemiBoldText(text: AppLocalizations.of(context).noParkingNearby, fontSize: 19, color: AppColor.forText),),
                               );
                             }
                           }
                           if(snapshot.hasError){
                             debugPrint('Error: ${snapshot.error}');
-                              return const SizedBox(
+                              return SizedBox(
                               width: double.infinity,
                               height: 310,
-                              child: Center(child: SemiBoldText(text: '[E]Không có bãi xe gần bạn', fontSize: 19, color: AppColor.forText),),
+                              child: Center(child: SemiBoldText(text: AppLocalizations.of(context).errorNoParking, fontSize: 19, color: AppColor.forText),),
                             );
                           }
-                          return const SizedBox(
+                          return SizedBox(
                             width: double.infinity,
                             height: 310,
-                            child: Center(child: SemiBoldText(text: '[U]Không có bãi xe gần bạn', fontSize: 19, color: AppColor.forText),),
+                            child: Center(child: SemiBoldText(text: AppLocalizations.of(context).unknownNoParking, fontSize: 19, color: AppColor.forText),),
                           );
 
                         },),
@@ -247,9 +264,9 @@ class _HomePageState extends State<HomePage> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         const SizedBox(height: 16),
-                        const Padding(
-                          padding: EdgeInsets.only(left: 20.0, right: 16),
-                          child: TitleList(title: 'Danh sách nổi bật', page: ParkingListPage()),
+                        Padding(
+                          padding: const EdgeInsets.only(left: 20.0, right: 16),
+                          child: TitleList(title: AppLocalizations.of(context).featuredList, page: const ParkingListPage()),
                         ),
 
                         FutureBuilder<RatingHomeResponse>(
@@ -278,24 +295,24 @@ class _HomePageState extends State<HomePage> {
                                   itemCount: snapshot.data!.data!.length,
                                 );
                               }else {
-                                return const SizedBox(
+                                return SizedBox(
                                   width: double.infinity,
                                   height: 310,
-                                  child: Center(child: SemiBoldText(text: 'Không có bãi xe gần bạn', fontSize: 19, color: AppColor.forText),),
+                                  child: Center(child: SemiBoldText(text: AppLocalizations.of(context).noParkingNearby, fontSize: 19, color: AppColor.forText),),
                                 );
                               }
                             }
                             if(snapshot.hasError){
-                              return const SizedBox(
+                              return SizedBox(
                                 width: double.infinity,
                                 height: 510,
-                                child: Center(child: SemiBoldText(text: '[E]Không có bãi xe gần bạn', fontSize: 19, color: AppColor.forText),),
+                                child: Center(child: SemiBoldText(text: AppLocalizations.of(context).errorNoParking, fontSize: 19, color: AppColor.forText),),
                               );
                             }
-                            return const SizedBox(
+                            return SizedBox(
                               width: double.infinity,
                               height: 510,
-                              child: Center(child: SemiBoldText(text: '[U]Không có bãi xe gần bạn', fontSize: 19, color: AppColor.forText),),
+                              child: Center(child: SemiBoldText(text: AppLocalizations.of(context).unknownNoParking, fontSize: 19, color: AppColor.forText),),
                             );
                           },),
 
@@ -311,7 +328,7 @@ class _HomePageState extends State<HomePage> {
                                 MaterialPageRoute(builder: (context) => const ParkingListPage()),
                               );
                             },
-                            child: const SemiBoldText(text: 'Xem thêm', fontSize: 14, color: AppColor.navy),
+                            child: SemiBoldText(text: AppLocalizations.of(context).seeMore, fontSize: 14, color: AppColor.navy),
                           ),
                         ),
                         const SizedBox(height: 26,),

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+
+class AppLocalizations {
+  final Locale locale;
+
+  AppLocalizations(this.locale);
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+
+  static const Map<String, Map<String, String>> _localizedValues = {
+    'en': {
+      'your_location': 'Your location',
+      'near_you': 'Near you',
+      'featured_list': 'Featured list',
+      'no_parking_nearby': 'No parking nearby',
+      'error_no_parking': '[E]No parking nearby',
+      'unknown_no_parking': '[U]No parking nearby',
+      'see_more': 'See more',
+      'parking_list_title': 'Parking list',
+      'notifications_title': 'Notification',
+      'important_notification': 'Important notice',
+      'personal_info_title': 'Personal information',
+      'notice_title': 'Notice',
+      'ban_warning_one': 'We notify that if you continue not to arrive at the booked parking lot, we will suspend your service to maintain fairness and availability for all users.',
+      'ban_warning_two': 'Your service has been suspended for not following the booking schedule at the parking lot. Please contact us for details.',
+      'loading': 'Loading...',
+      'parking_detail_title': 'Parking details',
+      'not_found_parking': 'Parking not found'
+    },
+    'vi': {
+      'your_location': 'Vị trí của bạn',
+      'near_you': 'Gần bạn',
+      'featured_list': 'Danh sách nổi bật',
+      'no_parking_nearby': 'Không có bãi xe gần bạn',
+      'error_no_parking': '[E]Không có bãi xe gần bạn',
+      'unknown_no_parking': '[U]Không có bãi xe gần bạn',
+      'see_more': 'Xem thêm',
+      'parking_list_title': 'Danh sách bãi xe',
+      'notifications_title': 'Thông báo',
+      'important_notification': 'Thông báo quan trọng',
+      'personal_info_title': 'Thông tin cá nhân',
+      'notice_title': 'Thông báo',
+      'ban_warning_one': 'Chúng tôi xin thông báo rằng nếu bạn tiếp tục không đến bãi xe theo lịch đặt, chúng tôi sẽ phải ngưng sử dụng dịch vụ của bạn để duy trì công bằng và đảm bảo tính sẵn sàng cho tất cả người dùng.',
+      'ban_warning_two': 'Chúng tôi tiếc báo rằng dịch vụ của bạn đã bị tạm ngưng do không tuân thủ lịch đặt tại bãi xe. Để tiếp tục sử dụng dịch vụ, vui lòng liên hệ với chúng tôi để biết thêm chi tiết và hướng dẫn khắc phục. Chúng tôi rất mong nhận được sự hợp tác của bạn trong việc duy trì trật tự và công bằng cho cộng đồng người dùng của chúng tôi.',
+      'loading': 'Đang tải...',
+      'parking_detail_title': 'Chi tiết bãi xe',
+      'not_found_parking': 'Không tìm thấy bãi xe'
+    }
+  };
+
+  String _translate(String key) {
+    return _localizedValues[locale.languageCode]?[key] ??
+        _localizedValues['en']![key] ??
+        key;
+  }
+
+  String get yourLocation => _translate('your_location');
+  String get nearYou => _translate('near_you');
+  String get featuredList => _translate('featured_list');
+  String get noParkingNearby => _translate('no_parking_nearby');
+  String get errorNoParking => _translate('error_no_parking');
+  String get unknownNoParking => _translate('unknown_no_parking');
+  String get seeMore => _translate('see_more');
+  String get parkingListTitle => _translate('parking_list_title');
+  String get notificationsTitle => _translate('notifications_title');
+  String get importantNotification => _translate('important_notification');
+  String get personalInfoTitle => _translate('personal_info_title');
+  String get noticeTitle => _translate('notice_title');
+  String get banWarningOne => _translate('ban_warning_one');
+  String get banWarningTwo => _translate('ban_warning_two');
+  String get loading => _translate('loading');
+  String get parkingDetailTitle => _translate('parking_detail_title');
+  String get notFoundParking => _translate('not_found_parking');
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => ['en', 'vi'].contains(locale.languageCode);
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(AppLocalizations(locale));
+  }
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,10 +2,12 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:parkz/splash_page.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:parkz/utils/warning__flag_provider.dart';
 import 'package:provider/provider.dart';
+import 'l10n/app_localizations.dart';
 
 import 'network/api.dart';
 
@@ -61,10 +63,21 @@ class MyApp extends StatefulWidget {
 
   @override
   State<MyApp> createState() => _MyAppState();
+
+  static _MyAppState? of(BuildContext context) => context.findAncestorStateOfType<_MyAppState>();
 }
 
 class _MyAppState extends State<MyApp> {
   // This widget is the root of your application.
+  Locale _locale = const Locale('en', 'US');
+
+  Locale get locale => _locale;
+
+  void setLocale(Locale value) {
+    setState(() {
+      _locale = value;
+    });
+  }
 
 
   @override
@@ -120,6 +133,17 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Flutter Demo',
+      locale: _locale,
+      supportedLocales: const [
+        Locale('en', 'US'),
+        Locale('vi', 'VN'),
+      ],
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),

--- a/lib/notification/component/notification_card.dart
+++ b/lib/notification/component/notification_card.dart
@@ -4,6 +4,7 @@ import 'package:parkz/utils/text/regular.dart';
 
 import '../../utils/constanst.dart';
 import '../../utils/text/semi_bold.dart';
+import '../../l10n/app_localizations.dart';
 
 class NotificationCard extends StatefulWidget {
   const NotificationCard({Key? key}) : super(key: key);
@@ -43,14 +44,14 @@ class _NotificationCardState extends State<NotificationCard> {
               Flexible(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
-                  children: const [
+                  children: [
                     SemiBoldText(
-                        text: 'Thông báo quan trọng',
+                        text: AppLocalizations.of(context).importantNotification,
                         color: AppColor.forText,
                         maxLine: 1,
                         fontSize: 15),
-                    SizedBox(height: 5,),
-                    RegularText(
+                    const SizedBox(height: 5,),
+                    const RegularText(
                         text:
                             'Lorem ipsum dolor sit amet consecrate. Corvallis nec nibh tortor gravida tincidunt sapien.',
                         color: AppColor.forText,

--- a/lib/notification/notification_page.dart
+++ b/lib/notification/notification_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:parkz/notification/component/notification_card.dart';
 import 'package:parkz/utils/constanst.dart';
 import 'package:parkz/utils/text/semi_bold.dart';
+import '../l10n/app_localizations.dart';
 
 class NotificationPage extends StatefulWidget {
   const NotificationPage({Key? key}) : super(key: key);
@@ -22,7 +23,7 @@ class _NotificationPageState extends State<NotificationPage> {
             color: AppColor.forText
         ),
         backgroundColor: Colors.white,
-        title: const SemiBoldText(text: 'Thông báo', fontSize: 20, color: AppColor.forText),
+        title: SemiBoldText(text: AppLocalizations.of(context).notificationsTitle, fontSize: 20, color: AppColor.forText),
       ),
       body: ListView.builder(
         padding: const EdgeInsets.only(top: 10,bottom: 20, left: 15, right: 15),

--- a/lib/parkingdetail/parking_detail_page.dart
+++ b/lib/parkingdetail/parking_detail_page.dart
@@ -8,6 +8,7 @@ import 'package:parkz/utils/constanst.dart';
 import 'package:parkz/utils/loading/loading_page.dart';
 import 'package:parkz/utils/text/medium.dart';
 import 'package:parkz/utils/text/regular.dart';
+import '../l10n/app_localizations.dart';
 import 'package:parkz/utils/text/semi_bold.dart';
 
 class ParkingDetailPage extends StatefulWidget {
@@ -97,7 +98,7 @@ class _ParkingDetailPageState extends State<ParkingDetailPage> {
               elevation: 0.0,
               leading: const BackButton(color: AppColor.forText),
               backgroundColor: Colors.white,
-              title: const SemiBoldText(text: 'Chi tiết bãi xe', fontSize: 20, color: AppColor.forText),
+              title: SemiBoldText(text: AppLocalizations.of(context).parkingDetailTitle, fontSize: 20, color: AppColor.forText),
             ),
 
             bottomNavigationBar: BottomParkingBar(containerPadding: containerPadding),
@@ -254,9 +255,9 @@ class _ParkingDetailPageState extends State<ParkingDetailPage> {
             ),
           );
         }
-        return const Scaffold(
+        return Scaffold(
           body: Center(
-            child: SemiBoldText(text: 'Không tìm thấy bãi xe', fontSize: 25, color: AppColor.forText, ),
+            child: SemiBoldText(text: AppLocalizations.of(context).notFoundParking, fontSize: 25, color: AppColor.forText, ),
           ),
         );
       }

--- a/lib/parkinglist/parking_list_page.dart
+++ b/lib/parkinglist/parking_list_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:parkz/utils/constanst.dart';
 import 'package:parkz/utils/text/semi_bold.dart';
+import '../l10n/app_localizations.dart';
 
 import '../home/components/parking_horizontal_card.dart';
 import '../home/components/parking_horizontal_shim_list.dart';
@@ -20,7 +21,7 @@ class ParkingListPage extends StatelessWidget {
             color: AppColor.forText
         ),
         backgroundColor: Colors.white,
-        title: const SemiBoldText(text: 'Danh sách bãi xe', fontSize: 20, color: AppColor.forText),
+        title: SemiBoldText(text: AppLocalizations.of(context).parkingListTitle, fontSize: 20, color: AppColor.forText),
       ),
       body: FutureBuilder<RatingHomeResponse>(
         future: getParkingListHome(100),
@@ -47,24 +48,24 @@ class ParkingListPage extends StatelessWidget {
                 itemCount: snapshot.data!.data!.length,
               );
             }else {
-              return const SizedBox(
+              return SizedBox(
                 width: double.infinity,
                 height: 310,
-                child: Center(child: SemiBoldText(text: 'Không có bãi xe gần bạn', fontSize: 19, color: AppColor.forText),),
+                child: Center(child: SemiBoldText(text: AppLocalizations.of(context).noParkingNearby, fontSize: 19, color: AppColor.forText),),
               );
             }
           }
           if(snapshot.hasError){
-            return const SizedBox(
+            return SizedBox(
               width: double.infinity,
               height: 510,
-              child: Center(child: SemiBoldText(text: '[E]Không có bãi xe gần bạn', fontSize: 19, color: AppColor.forText),),
+              child: Center(child: SemiBoldText(text: AppLocalizations.of(context).errorNoParking, fontSize: 19, color: AppColor.forText),),
             );
           }
-          return const SizedBox(
+          return SizedBox(
             width: double.infinity,
             height: 510,
-            child: Center(child: SemiBoldText(text: '[U]Không có bãi xe gần bạn', fontSize: 19, color: AppColor.forText),),
+            child: Center(child: SemiBoldText(text: AppLocalizations.of(context).unknownNoParking, fontSize: 19, color: AppColor.forText),),
           );
         },),
     );

--- a/lib/personalinformation/personal_information_page.dart
+++ b/lib/personalinformation/personal_information_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:parkz/utils/constanst.dart';
 
 import '../utils/text/semi_bold.dart';
+import '../l10n/app_localizations.dart';
 
 class PersonalInformationPage extends StatefulWidget {
   const PersonalInformationPage({Key? key}) : super(key: key);
@@ -20,8 +21,8 @@ class _PersonalInformationPageState extends State<PersonalInformationPage> {
           leading: const BackButton(color: AppColor.forText),
           elevation: 0,
           backgroundColor: Colors.transparent,
-          title: const SemiBoldText(
-              text: 'Thông tin cá nhân', fontSize: 20, color: AppColor.forText),
+          title: SemiBoldText(
+              text: AppLocalizations.of(context).personalInfoTitle, fontSize: 20, color: AppColor.forText),
           actions: [
             isEdit == false
                 ? IconButton(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
 
   # The following adds the Cupertino Icons font to your application.
@@ -93,6 +95,7 @@ flutter_icons:
 
 flutter:
   uses-material-design: true
+  generate: true
   assets:
     # images
     - assets/


### PR DESCRIPTION
## Summary
- add `flutter_localizations` config and enable generation
- implement a simple localization class with English and Vietnamese strings
- default the app locale to English and support runtime switching
- replace hard-coded Vietnamese text in several screens with localized lookups
- provide a language toggle button on the home page

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866de01fde483208869a2649387af23